### PR TITLE
fix: set environment context on build job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
     name: Build Apps & Functions
     runs-on: ubuntu-latest
     needs: test_and_lint
+    environment: ${{ github.ref == 'refs/heads/main' && 'production' || github.event.inputs.environment || 'development' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Sets the environment context on the build job so that environment-specific secrets (like Firebase client keys, Sentry DSNs, and Stripe publishable keys) are correctly resolved and injected into the client bundle during compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to manage environment settings more dynamically based on deployment context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->