### PR TITLE
chore: separate manual website deployment pipeline

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@1d0ff469b62b6d0ad9b0af0fb3b1e40be53ce9b9 # v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb7d863572879555776d52f6d # v4.2.0
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
This PR separates the website manual deployment pipeline into a standalone, production-only workflow.

### Key Changes:
- Reverts unified website deployment conditional changes from \deploy.yml\.
- Re-creates the standalone \.github/workflows/deploy-website.yml\ manual workflow, hardcoded to run in the \production\ environment with the manual review gate.
- Hardens the new standalone workflow by pinning actions to specific commit SHAs (checkout v4.2.2, setup-node v4.2.0, GCP auth v2.1.7).
- Fixes the \setup-node\ action commit SHA typo so GHA runs successfully.
- Updates documentation in \docs/CICD_REFERENCE.md\ to reflect the new pipeline configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment infrastructure with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->