### PR TITLE
fix: correct setup-node commit SHA

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@1d0ff469b7ec7b3cb7d863572879555776d52f6d # v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
Correct actions/setup-node commit SHA to the official v4.2.0 hash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to use an updated version of the Node.js setup action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->